### PR TITLE
Chapter 3: Untyped Arithmetic Expressions

### DIFF
--- a/TaplLean.lean
+++ b/TaplLean.lean
@@ -1,1 +1,1 @@
-import TaplLean.Basic
+import TaplLean.Chapter1

--- a/TaplLean/Basic.lean
+++ b/TaplLean/Basic.lean
@@ -1,1 +1,0 @@
-def hello := "world"

--- a/TaplLean/Util.lean
+++ b/TaplLean/Util.lean
@@ -1,8 +1,0 @@
--- Util.lean
-
-universe u
-
-class StepRel (α : Type u) where
-  step : α → α → Prop
-
-infixr:50 " -> " => StepRel.step


### PR DESCRIPTION
Defines an arithmetic language, and a boolean language.
Proves certain facts about the grammar of the arithmetic language.
Defines the semantics in the boolean language, and proves some facts about it.
Namely the equivalence of the small-step and big-step semantics of the boolean language.